### PR TITLE
Fixes #5: CNPJ generator

### DIFF
--- a/packages/generate-cnpj/README.md
+++ b/packages/generate-cnpj/README.md
@@ -1,0 +1,24 @@
+# @brazilian-utils/generate-cnpj
+
+Generates a valid CNPJ
+
+## Installation
+
+```sh
+# Yarn
+yarn add @brazilian-utils/generate-cnpj
+
+# npm
+npm install @brazilian-utils/generate-cnpj --save
+
+# UMD
+<script type='text/javascript' src='https://unpkg.com/@brazilian-utils/generate-cnpj/dist/index.umd.js'></script>
+```
+
+## Usage
+
+```js
+import generateCnpj from '@brazilian-utils/generate-cnpj';
+
+generateCnpj(); // return a valid CNPJ (numbers only)
+```

--- a/packages/generate-cnpj/package.json
+++ b/packages/generate-cnpj/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@brazilian-utils/generate-cnpj",
+  "description": "Generates a valid CNPJ",
+  "version": "0.1.5",
+  "main": "dist/index.js",
+  "umd:main": "dist/index.umd.js",
+  "module": "dist/index.m.js",
+  "source": "src/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "microbundle"
+  },
+  "repository": "https://github.com/hyanmandian/brazilian-utils/tree/master/packages/generate-cnpj",
+  "bugs": {
+    "url": "https://github.com/hyanmandian/brazilian-utils/issues"
+  },
+  "keywords": [
+    "cnpj",
+    "brasil",
+    "brazilian",
+    "utils",
+    "generator"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "@brazilian-utils/is-valid-cnpj": "^0.1.11",
+    "microbundle": "^0.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/generate-cnpj/src/cnpj.js
+++ b/packages/generate-cnpj/src/cnpj.js
@@ -1,0 +1,26 @@
+export const CNPJ_LENGTH = 14;
+
+export const FIRST_DIGIT_WEIGHTS = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+
+export const SECOND_DIGIT_WEIGHTS = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+
+export const generateRandomNumbers = n =>
+  Array(n)
+    .fill(0)
+    .map(() =>
+      Math.random()
+        .toString()
+        .substr(2, 1)
+    );
+
+export const multiplyWeights = (numbers, weights) => numbers.map((number, index) => number * weights[index]);
+
+export const sumNumbers = numbers => numbers.reduce((sum, number) => sum + number);
+
+export const calculateNthDigit = sum => {
+  const mod = sum % 11;
+
+  return Math.abs(mod < 2 ? 0 : mod - 11);
+};
+
+export const concatDigits = digits => digits.reduce((string, digit) => string + digit, '');

--- a/packages/generate-cnpj/src/index.js
+++ b/packages/generate-cnpj/src/index.js
@@ -1,0 +1,20 @@
+import {
+  CNPJ_LENGTH,
+  FIRST_DIGIT_WEIGHTS,
+  SECOND_DIGIT_WEIGHTS,
+  generateRandomNumbers,
+  multiplyWeights,
+  sumNumbers,
+  calculateNthDigit,
+  concatDigits,
+} from './cnpj';
+
+export default function generateCnpj() {
+  const twelveNumbers = generateRandomNumbers(CNPJ_LENGTH - 2);
+  const thirteenth = calculateNthDigit(sumNumbers(multiplyWeights(twelveNumbers, FIRST_DIGIT_WEIGHTS)));
+  const fourteenth = calculateNthDigit(
+    sumNumbers(multiplyWeights([...twelveNumbers, thirteenth], SECOND_DIGIT_WEIGHTS))
+  );
+
+  return concatDigits([...twelveNumbers, thirteenth, fourteenth]);
+}

--- a/packages/generate-cnpj/src/test/cnpj.test.js
+++ b/packages/generate-cnpj/src/test/cnpj.test.js
@@ -1,0 +1,62 @@
+import isValidCnpj from '@brazilian-utils/is-valid-cnpj';
+
+import {
+  CNPJ_LENGTH,
+  FIRST_DIGIT_WEIGHTS,
+  SECOND_DIGIT_WEIGHTS,
+  generateRandomNumbers,
+  multiplyWeights,
+  sumNumbers,
+  calculateNthDigit,
+  concatDigits,
+} from '../cnpj';
+
+describe('cnpj', () => {
+  const block1 = [1, 1, 4, 4, 4, 7, 7, 7, 0, 0, 0, 1];
+  const block2 = [1, 1, 4, 4, 4, 7, 7, 7, 0, 0, 0, 1, 6];
+
+  test('Generate N random numbers', () => {
+    expect(generateRandomNumbers(12).length).toBe(12);
+  });
+
+  test('Multiply numbers to weights', () => {
+    expect([5, 4, 12, 8, 36, 56, 49, 42, 0, 0, 0, 2]).toEqual(multiplyWeights(block1, FIRST_DIGIT_WEIGHTS));
+    expect([6, 5, 16, 12, 8, 63, 56, 49, 0, 0, 0, 3, 12]).toEqual(multiplyWeights(block2, SECOND_DIGIT_WEIGHTS));
+  });
+
+  test('Sum all numbers multiplied', () => {
+    expect(sumNumbers([1, 2, 2, 5])).toBe(10);
+    expect(sumNumbers(multiplyWeights(block1, FIRST_DIGIT_WEIGHTS))).toBe(214);
+    expect(sumNumbers(multiplyWeights(block2, SECOND_DIGIT_WEIGHTS))).toBe(230);
+  });
+
+  test('Nth digit with quocient smaller than 2', () => {
+    expect(calculateNthDigit(12)).toBe(0);
+  });
+
+  test('Nth digit with quocient greater than 2', () => {
+    expect(calculateNthDigit(214)).toBe(6);
+    expect(calculateNthDigit(230)).toBe(1);
+  });
+
+  test('Concat all numbers generated', () => {
+    expect(concatDigits(['12', '3', '4'])).toBe('1234');
+  });
+
+  test('Manual CNPJ validation', () => {
+    const firstBlock = [1, 1, 4, 4, 4, 7, 7, 7, 0, 0, 0, 1];
+
+    const firstDigit = calculateNthDigit(sumNumbers(multiplyWeights(firstBlock, FIRST_DIGIT_WEIGHTS)));
+    expect(firstDigit).toBe(6);
+
+    const secondDigit = calculateNthDigit(
+      sumNumbers(multiplyWeights([...firstBlock, firstDigit], SECOND_DIGIT_WEIGHTS))
+    );
+    expect(secondDigit).toBe(1);
+
+    const cnpj = concatDigits([firstBlock.join(''), firstDigit, secondDigit]);
+    expect(cnpj.length).toBe(CNPJ_LENGTH);
+    expect(cnpj).toBe('11444777000161');
+    expect(isValidCnpj(cnpj)).toBe(true);
+  });
+});

--- a/packages/generate-cnpj/src/test/index.test.js
+++ b/packages/generate-cnpj/src/test/index.test.js
@@ -1,0 +1,8 @@
+import isValidCnpj from '@brazilian-utils/is-valid-cnpj';
+import generateCnpj from '../index';
+
+describe('cnpjGenerator', () => {
+  test('It can generate a valid CNPJ', () => {
+    expect(isValidCnpj(generateCnpj())).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR adds a function to generate a valid CNPJ. The code was written based on information from [this](https://www.geradorcnpj.com/algoritmo_do_cnpj.htm) site and tested using the module `is-valid-cnpj`.

Please, let me know if you have any comments.