### PR TITLE
changes supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ cache:
     - node_modules
 
 node_js:
+  - '13'
+  - '12'
   - '11'
   - '10'
-  - '8'
-  - '6'
 
 env:
   global:


### PR DESCRIPTION
Changing the supported node versions, because one of the libraries are not building on node 6