### PR TITLE
feat: add cep formatter

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -71,3 +71,13 @@ import { isValidPIS } from '@brazilian-utils/brazilian-utils';
 
 isValidPIS('12056412547'); // false
 ```
+
+## formatCEP
+
+Format CEP ([brazilian postal code](https://en.wikipedia.org/wiki/C%C3%B3digo_de_Endere%C3%A7amento_Postal)).
+
+```javascript
+import { formatCEP } from '@brazilian-utils/brazilian-utils';
+
+formatCEP('92500000'); // 92500-000
+```

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,6 +4,7 @@ describe('Public API', () => {
   const methods = [
     'formatCPF',
     'isValidCEP',
+    'formatCEP',
     'isValidPIS',
     'isLastChar',
     'isValidCPF',

--- a/src/utilities/cep/index.test.ts
+++ b/src/utilities/cep/index.test.ts
@@ -1,4 +1,26 @@
-import { isValid, LENGTH } from '.';
+import { format, isValid, LENGTH } from '.';
+
+describe('format', () => {
+  test('should format CEP with mask', () => {
+    expect(format('')).toBe('');
+    expect(format('0')).toBe('0');
+    expect(format('01')).toBe('01');
+    expect(format('010')).toBe('010');
+    expect(format('0100')).toBe('0100');
+    expect(format('01001')).toBe('01001');
+    expect(format('010010')).toBe('01001-0');
+    expect(format('0100100')).toBe('01001-00');
+    expect(format('01001000')).toBe('01001-000');
+  });
+
+  test(`should NOT add digits after the CEP length (${LENGTH})`, () => {
+    expect(format('01001000000000')).toBe('01001-000');
+  });
+
+  test('should remove all non numeric characters', () => {
+    expect(format('a0.10cr01?00#ab0')).toBe('01001-000');
+  });
+});
 
 describe('isValid', () => {
   describe('should return false', () => {

--- a/src/utilities/cep/index.ts
+++ b/src/utilities/cep/index.ts
@@ -1,9 +1,28 @@
-import { onlyNumbers } from '../../helpers';
+import { isLastChar, onlyNumbers } from '../../helpers';
 
 export const LENGTH = 8;
 
+export const HYPHEN_INDEXES = [4];
+
 function isValidLength(cep: string) {
   return cep.length === LENGTH;
+}
+
+export function format(cep: string): string {
+  const digits = onlyNumbers(cep);
+
+  return digits
+    .slice(0, LENGTH)
+    .split('')
+    .reduce((acc, digit, i) => {
+      const result = `${acc}${digit}`;
+
+      if (!isLastChar(i, digits)) {
+        if (HYPHEN_INDEXES.indexOf(i) >= 0) return `${result}-`;
+      }
+
+      return result;
+    }, '');
 }
 
 export function isValid(cep: string) {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,8 +1,8 @@
 export { isValid as isValidPIS } from './pis';
-export { isValid as isValidCEP } from './cep';
 export { isValid as isValidPhone } from './phone';
 export { isValid as isValidEmail } from './email';
 export { format as formatJudicialProcess } from './judicial-process';
+export { format as formatCEP, isValid as isValidCEP } from './cep';
 export { format as formatBoleto, isValid as isValidBoleto } from './boleto';
 export { format as formatCPF, generate as generateCPF, isValid as isValidCPF } from './cpf';
 export { format as formatCNPJ, generate as generateCNPJ, isValid as isValidCNPJ } from './cnpj';


### PR DESCRIPTION
I found the need to have a CEP formatter to get the data from APIs and display to the user. Some of the data have nothing but digits and others have a dot in them. This package should work for both cases.