### PR TITLE
Format accepts numbers and have an alternate fillZeroes behavior

### DIFF
--- a/docs/pt-br/utilities.md
+++ b/docs/pt-br/utilities.md
@@ -12,6 +12,17 @@ import { isValidCPF } from '@brazilian-utils/brazilian-utils';
 isValidCPF('155151475'); // false
 ```
 
+## formatCPF
+
+Formata o CPF.
+
+```javascript
+import { formatCPF } from '@brazilian-utils/brazilian-utils';
+
+formatCPF('746506880') // 746.506.880
+formatCPF('746506880', { pad: true }) // 007.465.068-80
+```
+
 ## isValidCNPJ
 
 Valida se o CNPJ é válido.
@@ -21,6 +32,16 @@ import { isValidCNPJ } from '@brazilian-utils/brazilian-utils';
 
 isValidCNPJ('15515147234255'); // false
 ```
+
+## formatCNPJ
+
+Formata o CNPJ.
+
+```javascript
+import { formatCNPJ } from '@brazilian-utils/brazilian-utils';
+
+formatCNPJ('245222000174') // 24.522.200/0174
+formatCNPJ('245222000174', { pad: true }) // 00.245.222/0001-74
 
 ## isValidCEP
 

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -12,6 +12,17 @@ import { isValidCPF } from '@brazilian-utils/brazilian-utils';
 isValidCPF('155151475'); // false
 ```
 
+## formatCPF
+
+Format CPF.
+
+```javascript
+import { formatCPF } from '@brazilian-utils/brazilian-utils';
+
+formatCPF('746506880') // 746.506.880
+formatCPF('746506880', { pad: true }) // 007.465.068-80
+```
+
 ## isValidCNPJ
 
 Check if CNPJ is valid.
@@ -20,6 +31,17 @@ Check if CNPJ is valid.
 import { isValidCNPJ } from '@brazilian-utils/brazilian-utils';
 
 isValidCNPJ('15515147234255'); // false
+```
+
+## formatCNPJ
+
+Format CNPJ.
+
+```javascript
+import { formatCNPJ } from '@brazilian-utils/brazilian-utils';
+
+formatCNPJ('245222000174') // 24.522.200/0174
+formatCNPJ('245222000174', { pad: true }) // 00.245.222/0001-74
 ```
 
 ## isValidCEP

--- a/src/utilities/cnpj/index.test.ts
+++ b/src/utilities/cnpj/index.test.ts
@@ -37,38 +37,38 @@ describe('format', () => {
   });
 
   test('should format cnpj with mask filling zeroes', () => {
-    expect(format('', true)).toBe('00.000.000/0000-00');
-    expect(format('4', true)).toBe('00.000.000/0000-04');
-    expect(format('46', true)).toBe('00.000.000/0000-46');
-    expect(format('468', true)).toBe('00.000.000/0004-68');
-    expect(format('4684', true)).toBe('00.000.000/0046-84');
-    expect(format('46843', true)).toBe('00.000.000/0468-43');
-    expect(format('468434', true)).toBe('00.000.000/4684-34');
-    expect(format('4684348', true)).toBe('00.000.004/6843-48');
-    expect(format('46843485', true)).toBe('00.000.046/8434-85');
-    expect(format('468434850', true)).toBe('00.000.468/4348-50');
-    expect(format('4684348500', true)).toBe('00.004.684/3485-00');
-    expect(format('46843485000', true)).toBe('00.046.843/4850-00');
-    expect(format('468434850001', true)).toBe('00.468.434/8500-01');
-    expect(format('4684348500018', true)).toBe('04.684.348/5000-18');
-    expect(format('46843485000186', true)).toBe('46.843.485/0001-86');
+    expect(format('', { pad: true })).toBe('00.000.000/0000-00');
+    expect(format('4', { pad: true })).toBe('00.000.000/0000-04');
+    expect(format('46', { pad: true })).toBe('00.000.000/0000-46');
+    expect(format('468', { pad: true })).toBe('00.000.000/0004-68');
+    expect(format('4684', { pad: true })).toBe('00.000.000/0046-84');
+    expect(format('46843', { pad: true })).toBe('00.000.000/0468-43');
+    expect(format('468434', { pad: true })).toBe('00.000.000/4684-34');
+    expect(format('4684348', { pad: true })).toBe('00.000.004/6843-48');
+    expect(format('46843485', { pad: true })).toBe('00.000.046/8434-85');
+    expect(format('468434850', { pad: true })).toBe('00.000.468/4348-50');
+    expect(format('4684348500', { pad: true })).toBe('00.004.684/3485-00');
+    expect(format('46843485000', { pad: true })).toBe('00.046.843/4850-00');
+    expect(format('468434850001', { pad: true })).toBe('00.468.434/8500-01');
+    expect(format('4684348500018', { pad: true })).toBe('04.684.348/5000-18');
+    expect(format('46843485000186', { pad: true })).toBe('46.843.485/0001-86');
   });
 
   test('should format number cnpj with mask filling zeroes', () => {
-    expect(format(4, true)).toBe('00.000.000/0000-04');
-    expect(format(46, true)).toBe('00.000.000/0000-46');
-    expect(format(468, true)).toBe('00.000.000/0004-68');
-    expect(format(4684, true)).toBe('00.000.000/0046-84');
-    expect(format(46843, true)).toBe('00.000.000/0468-43');
-    expect(format(468434, true)).toBe('00.000.000/4684-34');
-    expect(format(4684348, true)).toBe('00.000.004/6843-48');
-    expect(format(46843485, true)).toBe('00.000.046/8434-85');
-    expect(format(468434850, true)).toBe('00.000.468/4348-50');
-    expect(format(4684348500, true)).toBe('00.004.684/3485-00');
-    expect(format(46843485000, true)).toBe('00.046.843/4850-00');
-    expect(format(468434850001, true)).toBe('00.468.434/8500-01');
-    expect(format(4684348500018, true)).toBe('04.684.348/5000-18');
-    expect(format(46843485000186, true)).toBe('46.843.485/0001-86');
+    expect(format(4, { pad: true })).toBe('00.000.000/0000-04');
+    expect(format(46, { pad: true })).toBe('00.000.000/0000-46');
+    expect(format(468, { pad: true })).toBe('00.000.000/0004-68');
+    expect(format(4684, { pad: true })).toBe('00.000.000/0046-84');
+    expect(format(46843, { pad: true })).toBe('00.000.000/0468-43');
+    expect(format(468434, { pad: true })).toBe('00.000.000/4684-34');
+    expect(format(4684348, { pad: true })).toBe('00.000.004/6843-48');
+    expect(format(46843485, { pad: true })).toBe('00.000.046/8434-85');
+    expect(format(468434850, { pad: true })).toBe('00.000.468/4348-50');
+    expect(format(4684348500, { pad: true })).toBe('00.004.684/3485-00');
+    expect(format(46843485000, { pad: true })).toBe('00.046.843/4850-00');
+    expect(format(468434850001, { pad: true })).toBe('00.468.434/8500-01');
+    expect(format(4684348500018, { pad: true })).toBe('04.684.348/5000-18');
+    expect(format(46843485000186, { pad: true })).toBe('46.843.485/0001-86');
   });
 
   test(`should NOT add digits after the CNPJ length (${LENGTH})`, () => {

--- a/src/utilities/cnpj/index.test.ts
+++ b/src/utilities/cnpj/index.test.ts
@@ -19,6 +19,58 @@ describe('format', () => {
     expect(format('46843485000186')).toBe('46.843.485/0001-86');
   });
 
+  test('should format number cnpj with mask', () => {
+    expect(format(4)).toBe('4');
+    expect(format(46)).toBe('46');
+    expect(format(468)).toBe('46.8');
+    expect(format(4684)).toBe('46.84');
+    expect(format(46843)).toBe('46.843');
+    expect(format(468434)).toBe('46.843.4');
+    expect(format(4684348)).toBe('46.843.48');
+    expect(format(46843485)).toBe('46.843.485');
+    expect(format(468434850)).toBe('46.843.485/0');
+    expect(format(4684348500)).toBe('46.843.485/00');
+    expect(format(46843485000)).toBe('46.843.485/000');
+    expect(format(468434850001)).toBe('46.843.485/0001');
+    expect(format(4684348500018)).toBe('46.843.485/0001-8');
+    expect(format(46843485000186)).toBe('46.843.485/0001-86');
+  });
+
+  test('should format cnpj with mask filling zeroes', () => {
+    expect(format('', true)).toBe('00.000.000/0000-00');
+    expect(format('4', true)).toBe('00.000.000/0000-04');
+    expect(format('46', true)).toBe('00.000.000/0000-46');
+    expect(format('468', true)).toBe('00.000.000/0004-68');
+    expect(format('4684', true)).toBe('00.000.000/0046-84');
+    expect(format('46843', true)).toBe('00.000.000/0468-43');
+    expect(format('468434', true)).toBe('00.000.000/4684-34');
+    expect(format('4684348', true)).toBe('00.000.004/6843-48');
+    expect(format('46843485', true)).toBe('00.000.046/8434-85');
+    expect(format('468434850', true)).toBe('00.000.468/4348-50');
+    expect(format('4684348500', true)).toBe('00.004.684/3485-00');
+    expect(format('46843485000', true)).toBe('00.046.843/4850-00');
+    expect(format('468434850001', true)).toBe('00.468.434/8500-01');
+    expect(format('4684348500018', true)).toBe('04.684.348/5000-18');
+    expect(format('46843485000186', true)).toBe('46.843.485/0001-86');
+  });
+
+  test('should format number cnpj with mask filling zeroes', () => {
+    expect(format(4, true)).toBe('00.000.000/0000-04');
+    expect(format(46, true)).toBe('00.000.000/0000-46');
+    expect(format(468, true)).toBe('00.000.000/0004-68');
+    expect(format(4684, true)).toBe('00.000.000/0046-84');
+    expect(format(46843, true)).toBe('00.000.000/0468-43');
+    expect(format(468434, true)).toBe('00.000.000/4684-34');
+    expect(format(4684348, true)).toBe('00.000.004/6843-48');
+    expect(format(46843485, true)).toBe('00.000.046/8434-85');
+    expect(format(468434850, true)).toBe('00.000.468/4348-50');
+    expect(format(4684348500, true)).toBe('00.004.684/3485-00');
+    expect(format(46843485000, true)).toBe('00.046.843/4850-00');
+    expect(format(468434850001, true)).toBe('00.468.434/8500-01');
+    expect(format(4684348500018, true)).toBe('04.684.348/5000-18');
+    expect(format(46843485000186, true)).toBe('46.843.485/0001-86');
+  });
+
   test(`should NOT add digits after the CNPJ length (${LENGTH})`, () => {
     expect(format('468434850001860000000000')).toBe('46.843.485/0001-86');
   });

--- a/src/utilities/cnpj/index.ts
+++ b/src/utilities/cnpj/index.ts
@@ -27,8 +27,12 @@ export const FIRST_CHECK_DIGIT_WEIGHTS = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
 
 export const SECOND_CHECK_DIGIT_WEIGHTS = [6, ...FIRST_CHECK_DIGIT_WEIGHTS];
 
-export function format(cnpj: string): string {
-  const digits = onlyNumbers(cnpj);
+export function format(cnpj: string | number, fillZeroes: boolean = false): string {
+  let digits = onlyNumbers(cnpj);
+
+  if (fillZeroes) {
+    digits = digits.padStart(LENGTH, '0');
+  }
 
   return digits
     .slice(0, LENGTH)

--- a/src/utilities/cnpj/index.ts
+++ b/src/utilities/cnpj/index.ts
@@ -27,10 +27,14 @@ export const FIRST_CHECK_DIGIT_WEIGHTS = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
 
 export const SECOND_CHECK_DIGIT_WEIGHTS = [6, ...FIRST_CHECK_DIGIT_WEIGHTS];
 
-export function format(cnpj: string | number, fillZeroes: boolean = false): string {
+export interface FormatCnpjOptions {
+  pad?: boolean;
+}
+
+export function format(cnpj: string | number, options: FormatCnpjOptions = {}): string {
   let digits = onlyNumbers(cnpj);
 
-  if (fillZeroes) {
+  if (options.pad) {
     digits = digits.padStart(LENGTH, '0');
   }
 

--- a/src/utilities/cpf/index.test.ts
+++ b/src/utilities/cpf/index.test.ts
@@ -32,32 +32,32 @@ describe('format', () => {
   });
 
   test('should format CPF with mask filling zeroes', () => {
-    expect(format('', true)).toBe('000.000.000-00');
-    expect(format('9', true)).toBe('000.000.000-09');
-    expect(format('94', true)).toBe('000.000.000-94');
-    expect(format('943', true)).toBe('000.000.009-43');
-    expect(format('9438', true)).toBe('000.000.094-38');
-    expect(format('94389', true)).toBe('000.000.943-89');
-    expect(format('943895', true)).toBe('000.009.438-95');
-    expect(format('9438957', true)).toBe('000.094.389-57');
-    expect(format('94389575', true)).toBe('000.943.895-75');
-    expect(format('943895751', true)).toBe('009.438.957-51');
-    expect(format('9438957510', true)).toBe('094.389.575-10');
-    expect(format('94389575104', true)).toBe('943.895.751-04');
+    expect(format('', { pad: true })).toBe('000.000.000-00');
+    expect(format('9', { pad: true })).toBe('000.000.000-09');
+    expect(format('94', { pad: true })).toBe('000.000.000-94');
+    expect(format('943', { pad: true })).toBe('000.000.009-43');
+    expect(format('9438', { pad: true })).toBe('000.000.094-38');
+    expect(format('94389', { pad: true })).toBe('000.000.943-89');
+    expect(format('943895', { pad: true })).toBe('000.009.438-95');
+    expect(format('9438957', { pad: true })).toBe('000.094.389-57');
+    expect(format('94389575', { pad: true })).toBe('000.943.895-75');
+    expect(format('943895751', { pad: true })).toBe('009.438.957-51');
+    expect(format('9438957510', { pad: true })).toBe('094.389.575-10');
+    expect(format('94389575104', { pad: true })).toBe('943.895.751-04');
   });
 
   test('should format number CPF with mask filling zeroes', () => {
-    expect(format(9, true)).toBe('000.000.000-09');
-    expect(format(94, true)).toBe('000.000.000-94');
-    expect(format(943, true)).toBe('000.000.009-43');
-    expect(format(9438, true)).toBe('000.000.094-38');
-    expect(format(94389, true)).toBe('000.000.943-89');
-    expect(format(943895, true)).toBe('000.009.438-95');
-    expect(format(9438957, true)).toBe('000.094.389-57');
-    expect(format(94389575, true)).toBe('000.943.895-75');
-    expect(format(943895751, true)).toBe('009.438.957-51');
-    expect(format(9438957510, true)).toBe('094.389.575-10');
-    expect(format(94389575104, true)).toBe('943.895.751-04');
+    expect(format(9, { pad: true })).toBe('000.000.000-09');
+    expect(format(94, { pad: true })).toBe('000.000.000-94');
+    expect(format(943, { pad: true })).toBe('000.000.009-43');
+    expect(format(9438, { pad: true })).toBe('000.000.094-38');
+    expect(format(94389, { pad: true })).toBe('000.000.943-89');
+    expect(format(943895, { pad: true })).toBe('000.009.438-95');
+    expect(format(9438957, { pad: true })).toBe('000.094.389-57');
+    expect(format(94389575, { pad: true })).toBe('000.943.895-75');
+    expect(format(943895751, { pad: true })).toBe('009.438.957-51');
+    expect(format(9438957510, { pad: true })).toBe('094.389.575-10');
+    expect(format(94389575104, { pad: true })).toBe('943.895.751-04');
   });
 
   test(`should NOT add digits after the CPF length (${LENGTH})`, () => {

--- a/src/utilities/cpf/index.test.ts
+++ b/src/utilities/cpf/index.test.ts
@@ -17,6 +17,49 @@ describe('format', () => {
     expect(format('94389575104')).toBe('943.895.751-04');
   });
 
+  test('should format number CPF with mask', () => {
+    expect(format(9)).toBe('9');
+    expect(format(94)).toBe('94');
+    expect(format(943)).toBe('943');
+    expect(format(9438)).toBe('943.8');
+    expect(format(94389)).toBe('943.89');
+    expect(format(943895)).toBe('943.895');
+    expect(format(9438957)).toBe('943.895.7');
+    expect(format(94389575)).toBe('943.895.75');
+    expect(format(943895751)).toBe('943.895.751');
+    expect(format(9438957510)).toBe('943.895.751-0');
+    expect(format(94389575104)).toBe('943.895.751-04');
+  });
+
+  test('should format CPF with mask filling zeroes', () => {
+    expect(format('', true)).toBe('000.000.000-00');
+    expect(format('9', true)).toBe('000.000.000-09');
+    expect(format('94', true)).toBe('000.000.000-94');
+    expect(format('943', true)).toBe('000.000.009-43');
+    expect(format('9438', true)).toBe('000.000.094-38');
+    expect(format('94389', true)).toBe('000.000.943-89');
+    expect(format('943895', true)).toBe('000.009.438-95');
+    expect(format('9438957', true)).toBe('000.094.389-57');
+    expect(format('94389575', true)).toBe('000.943.895-75');
+    expect(format('943895751', true)).toBe('009.438.957-51');
+    expect(format('9438957510', true)).toBe('094.389.575-10');
+    expect(format('94389575104', true)).toBe('943.895.751-04');
+  });
+
+  test('should format number CPF with mask filling zeroes', () => {
+    expect(format(9, true)).toBe('000.000.000-09');
+    expect(format(94, true)).toBe('000.000.000-94');
+    expect(format(943, true)).toBe('000.000.009-43');
+    expect(format(9438, true)).toBe('000.000.094-38');
+    expect(format(94389, true)).toBe('000.000.943-89');
+    expect(format(943895, true)).toBe('000.009.438-95');
+    expect(format(9438957, true)).toBe('000.094.389-57');
+    expect(format(94389575, true)).toBe('000.943.895-75');
+    expect(format(943895751, true)).toBe('009.438.957-51');
+    expect(format(9438957510, true)).toBe('094.389.575-10');
+    expect(format(94389575104, true)).toBe('943.895.751-04');
+  });
+
   test(`should NOT add digits after the CPF length (${LENGTH})`, () => {
     expect(format('94389575104000000')).toBe('943.895.751-04');
   });

--- a/src/utilities/cpf/index.ts
+++ b/src/utilities/cpf/index.ts
@@ -23,10 +23,14 @@ export const RESERVED_NUMBERS = [
 
 export const CHECK_DIGITS_INDEXES = [9, 10];
 
-export function format(cpf: string | number, fillZeroes: boolean = false): string {
+export interface FormatCpfOptions {
+  pad?: boolean;
+}
+
+export function format(cpf: string | number, options: FormatCpfOptions = {}): string {
   let digits = onlyNumbers(cpf);
 
-  if (fillZeroes) {
+  if (options.pad) {
     digits = digits.padStart(LENGTH, '0');
   }
 

--- a/src/utilities/cpf/index.ts
+++ b/src/utilities/cpf/index.ts
@@ -23,8 +23,12 @@ export const RESERVED_NUMBERS = [
 
 export const CHECK_DIGITS_INDEXES = [9, 10];
 
-export function format(cpf: string): string {
-  const digits = onlyNumbers(cpf);
+export function format(cpf: string | number, fillZeroes: boolean = false): string {
+  let digits = onlyNumbers(cpf);
+
+  if (fillZeroes) {
+    digits = digits.padStart(LENGTH, '0');
+  }
 
   return digits
     .slice(0, LENGTH)


### PR DESCRIPTION
This lib is great and the name is cool!

I have been using it, and sometimes I deal with number CPFs and 10-digit number CPFs.
I always have to pad an convert values.
It would be nice if the lib could handle it for me.

So the signatures of format methods would be:

```js
format(cpf: string | number, fillZeroes: boolean = false)
format(cnpj: string | number, fillZeroes: boolean = false)
```

All previous tests are working untouched and new tests were added.