### PR TITLE
fix: esm filename in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@brazilian-utils/brazilian-utils",
   "version": "1.0.0-rc.10",
   "main": "dist/index.js",
-  "module": "dist/brazilianUtils.esm.js",
+  "module": "dist/brazilian-utils.esm.js",
   "typings": "dist/index.d.ts",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
Previously, the package.json point to a file that not exists

![Screenshot_20200814_192459](https://user-images.githubusercontent.com/4311885/90297157-fd3d4100-de63-11ea-9bbe-c3f108c4cc3c.png)
