### PR TITLE
Add validadors for brazilian and mercosul license plates

### DIFF
--- a/docs/pt-br/utilities.md
+++ b/docs/pt-br/utilities.md
@@ -104,6 +104,16 @@ import { isValidLandlinePhone } from '@brazilian-utils/brazilian-utils';
 isValidLandlinePhone('1130000000'); // true
 ```
 
+## isValidLicensePlate
+
+Valida se a placa de carro é válida.
+
+```javascript
+import { isValidLicensePlate } from '@brazilian-utils/brazilian-utils';
+
+isValidLicensePlate('ABC1234'); // true
+```
+
 ## isValidPIS
 
 Valida se o PIS é válido.

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -104,6 +104,16 @@ import { isValidLandlinePhone } from '@brazilian-utils/brazilian-utils';
 isValidLandlinePhone('1130000000'); // true
 ```
 
+## isValidLicensePlate
+
+Check if license plate is valid.
+
+```javascript
+import { isValidLicensePlate } from '@brazilian-utils/brazilian-utils';
+
+isValidLicensePlate('ABC1234'); // true
+```
+
 ## isValidPIS
 
 Check if PIS is valid.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6797,7 +6797,6 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
           "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
@@ -6809,8 +6808,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,6 +10,7 @@ describe('Public API', () => {
     'isValidPIS',
     'isLastChar',
     'isValidCPF',
+    'isValidLicensePlate',
     'isValidIE',
     'formatCNPJ',
     'isValidCNPJ',

--- a/src/utilities/boleto/index.test.ts
+++ b/src/utilities/boleto/index.test.ts
@@ -2,15 +2,15 @@ import { isValid, format, LENGTH } from '.';
 
 describe('isValid', () => {
   describe('should return false', () => {
-    test('when is a empty string', () => {
+    test('when it is an empty string', () => {
       expect(isValid('')).toBe(false);
     });
 
-    test('when is null', () => {
+    test('when it is null', () => {
       expect(isValid(null as any)).toBe(false);
     });
 
-    test('when is undefined', () => {
+    test('when it is undefined', () => {
       expect(isValid(undefined as any)).toBe(false);
     });
 

--- a/src/utilities/cep/index.test.ts
+++ b/src/utilities/cep/index.test.ts
@@ -24,13 +24,13 @@ describe('format', () => {
 
 describe('isValid', () => {
   describe('should return false', () => {
-    test('when is a empty string', () => {
+    test('when it is an empty string', () => {
       expect(isValid('')).toBe(false);
     });
-    test('when is null', () => {
+    test('when it is null', () => {
       expect(isValid(null as any)).toBe(false);
     });
-    test('when is undefined', () => {
+    test('when it is undefined', () => {
       expect(isValid(undefined as any)).toBe(false);
     });
     test(`when length is greater than ${LENGTH}`, () => {

--- a/src/utilities/cnpj/index.test.ts
+++ b/src/utilities/cnpj/index.test.ts
@@ -99,28 +99,28 @@ describe('isValid', () => {
       RESERVED_NUMBERS.forEach((cnpj) => expect(isValid(cnpj)).toBe(false));
     });
 
-    test('when is a empty string', () => {
+    test('when it is an empty string', () => {
       expect(isValid('')).toBe(false);
     });
 
-    test('when is null', () => {
+    test('when it is null', () => {
       expect(isValid(null as any)).toBe(false);
     });
 
-    test('when is undefined', () => {
+    test('when it is undefined', () => {
       expect(isValid(undefined as any)).toBe(false);
     });
 
-    test('when is a boolean', () => {
+    test('when it is a boolean', () => {
       expect(isValid(true as any)).toBe(false);
       expect(isValid(false as any)).toBe(false);
     });
 
-    test('when is a object', () => {
+    test('when it is an object', () => {
       expect(isValid({} as any)).toBe(false);
     });
 
-    test('when is a array', () => {
+    test('when it is an array', () => {
       expect(isValid([] as any)).toBe(false);
     });
 

--- a/src/utilities/cpf/index.test.ts
+++ b/src/utilities/cpf/index.test.ts
@@ -96,28 +96,28 @@ describe('isValid', () => {
       RESERVED_NUMBERS.forEach((cpf) => expect(isValid(cpf)).toBe(false));
     });
 
-    test('when is a empty string', () => {
+    test('when it is an empty string', () => {
       expect(isValid('')).toBe(false);
     });
 
-    test('when is null', () => {
+    test('when it is null', () => {
       expect(isValid(null as any)).toBe(false);
     });
 
-    test('when is undefined', () => {
+    test('when it is undefined', () => {
       expect(isValid(undefined as any)).toBe(false);
     });
 
-    test('when is a boolean', () => {
+    test('when it is a boolean', () => {
       expect(isValid(true as any)).toBe(false);
       expect(isValid(false as any)).toBe(false);
     });
 
-    test('when is a object', () => {
+    test('when it is an object', () => {
       expect(isValid({} as any)).toBe(false);
     });
 
-    test('when is a array', () => {
+    test('when it is an array', () => {
       expect(isValid([] as any)).toBe(false);
     });
 

--- a/src/utilities/email/index.test.ts
+++ b/src/utilities/email/index.test.ts
@@ -6,28 +6,28 @@ import { isValid } from '.';
 
 describe('isValid', () => {
   describe('should return false', () => {
-    test('when is a empty string', () => {
+    test('when it is an empty string', () => {
       expect(isValid('')).toBe(false);
     });
 
-    test('when is null', () => {
+    test('when it is null', () => {
       expect(isValid(null as any)).toBe(false);
     });
 
-    test('when is undefined', () => {
+    test('when it is undefined', () => {
       expect(isValid(undefined as any)).toBe(false);
     });
 
-    test('when is a boolean', () => {
+    test('when it is a boolean', () => {
       expect(isValid(true as any)).toBe(false);
       expect(isValid(false as any)).toBe(false);
     });
 
-    test('when is a object', () => {
+    test('when it is an object', () => {
       expect(isValid({} as any)).toBe(false);
     });
 
-    test('when is a array', () => {
+    test('when it is an array', () => {
       expect(isValid([] as any)).toBe(false);
     });
 

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -2,6 +2,7 @@ export { isValid as isValidIE } from './inscricao-estadual';
 export { isValid as isValidPIS } from './pis';
 export { isValid as isValidPhone, isValidMobilePhone, isValidLandlinePhone } from './phone';
 export { isValid as isValidEmail } from './email';
+export { isValid as isValidLicensePlate } from './licensePlate';
 export { format as formatPJ } from './processo-juridico';
 export { format as formatCEP, isValid as isValidCEP } from './cep';
 export { format as formatBoleto, isValid as isValidBoleto } from './boleto';

--- a/src/utilities/licensePlate/index.test.ts
+++ b/src/utilities/licensePlate/index.test.ts
@@ -1,7 +1,3 @@
-// Tests created using the following links as reference:
-// https://help.returnpath.com/hc/en-us/articles/220560587-What-are-the-rules-for-email-address-syntax-
-// https://stackoverflow.com/questions/2049502/what-characters-are-allowed-in-an-email-address
-
 import { isValid } from '.';
 
 describe('isValid', () => {

--- a/src/utilities/licensePlate/index.test.ts
+++ b/src/utilities/licensePlate/index.test.ts
@@ -1,0 +1,52 @@
+// Tests created using the following links as reference:
+// https://help.returnpath.com/hc/en-us/articles/220560587-What-are-the-rules-for-email-address-syntax-
+// https://stackoverflow.com/questions/2049502/what-characters-are-allowed-in-an-email-address
+
+import { isValid } from '.';
+
+describe('isValid', () => {
+  describe('should return false', () => {
+    test('when it is an empty string', () => {
+      expect(isValid('')).toBe(false);
+    });
+
+    test('when it is null', () => {
+      expect(isValid(null as any)).toBe(false);
+    });
+
+    test('when it is undefined', () => {
+      expect(isValid(undefined as any)).toBe(false);
+    });
+
+    test('when it is a boolean', () => {
+      expect(isValid(true as any)).toBe(false);
+      expect(isValid(false as any)).toBe(false);
+    });
+
+    test('when it is an object', () => {
+      expect(isValid({} as any)).toBe(false);
+    });
+
+    test('when it is an array', () => {
+      expect(isValid([] as any)).toBe(false);
+    });
+    test('when brazilian license plate format is invalid', () => {
+      expect(isValid('abc12345')).toBe(false);
+      expect(isValid('5abc1234')).toBe(false);
+      expect(isValid('abcd1234')).toBe(false);
+      expect(isValid('abcd234')).toBe(false);
+    });
+  });
+  describe('should return true', () => {
+    test('when brazilian license plate format is valid', () => {
+      expect(isValid('abc1234')).toBe(true);
+      expect(isValid('ABC1234')).toBe(true);
+      expect(isValid('abc-1234')).toBe(true);
+      expect(isValid('ABC-1234')).toBe(true);
+    });
+    test('when mercosul license plate format is valid', () => {
+      expect(isValid('abc1d23')).toBe(true);
+      expect(isValid('ABC1D23')).toBe(true);
+    });
+  });
+});

--- a/src/utilities/licensePlate/index.ts
+++ b/src/utilities/licensePlate/index.ts
@@ -1,0 +1,12 @@
+const validMercosulLicensePlateRegex = /^[a-zA-Z]{3}[0-9]{1}[a-zA-Z]{1}[0-9]{2}$/;
+const validBrazilianLicensePlateRegex = /^[a-zA-Z]{3}-?[0-9]{4}$/;
+
+export function isValid(licensePlate: string): boolean {
+  if (!licensePlate || typeof licensePlate !== 'string') return false;
+
+  const matchedLicensePlate =
+    validMercosulLicensePlateRegex.exec(licensePlate) || validBrazilianLicensePlateRegex.exec(licensePlate);
+  if (!matchedLicensePlate) return false;
+
+  return true;
+}

--- a/src/utilities/licensePlate/index.ts
+++ b/src/utilities/licensePlate/index.ts
@@ -1,12 +1,7 @@
-const validMercosulLicensePlateRegex = /^[a-zA-Z]{3}[0-9]{1}[a-zA-Z]{1}[0-9]{2}$/;
-const validBrazilianLicensePlateRegex = /^[a-zA-Z]{3}-?[0-9]{4}$/;
+const validMercosulLicensePlateRegex = /^[a-z]{3}[0-9]{1}[a-z]{1}[0-9]{2}$/i;
+const validBrazilianLicensePlateRegex = /^[a-z]{3}-?[0-9]{4}$/i;
 
 export function isValid(licensePlate: string): boolean {
   if (!licensePlate || typeof licensePlate !== 'string') return false;
-
-  const matchedLicensePlate =
-    validMercosulLicensePlateRegex.exec(licensePlate) || validBrazilianLicensePlateRegex.exec(licensePlate);
-  if (!matchedLicensePlate) return false;
-
-  return true;
+  return validMercosulLicensePlateRegex.test(licensePlate) || validBrazilianLicensePlateRegex.test(licensePlate);
 }

--- a/src/utilities/phone/index.test.ts
+++ b/src/utilities/phone/index.test.ts
@@ -9,25 +9,25 @@ import {
 
 describe('isValid', () => {
   describe('should return false', () => {
-    test('when is a empty string', () => {
+    test('when it is an empty string', () => {
       expect(isValid('')).toBe(false);
       expect(isValidMobilePhone('')).toBe(false);
       expect(isValidLandlinePhone('')).toBe(false);
     });
 
-    test('when is null', () => {
+    test('when it is null', () => {
       expect(isValid(null as any)).toBe(false);
       expect(isValidMobilePhone(null as any)).toBe(false);
       expect(isValidLandlinePhone(null as any)).toBe(false);
     });
 
-    test('when is undefined', () => {
+    test('when it is undefined', () => {
       expect(isValid(undefined as any)).toBe(false);
       expect(isValidMobilePhone(undefined as any)).toBe(false);
       expect(isValidLandlinePhone(undefined as any)).toBe(false);
     });
 
-    test('when is a boolean', () => {
+    test('when it is a boolean', () => {
       expect(isValid(true as any)).toBe(false);
       expect(isValid(false as any)).toBe(false);
       expect(isValidMobilePhone(false as any)).toBe(false);
@@ -36,13 +36,13 @@ describe('isValid', () => {
       expect(isValidLandlinePhone(true as any)).toBe(false);
     });
 
-    test('when is a object', () => {
+    test('when it is an object', () => {
       expect(isValid({} as any)).toBe(false);
       expect(isValidMobilePhone({} as any)).toBe(false);
       expect(isValidLandlinePhone({} as any)).toBe(false);
     });
 
-    test('when is a array', () => {
+    test('when it is an array', () => {
       expect(isValid([] as any)).toBe(false);
       expect(isValidMobilePhone([] as any)).toBe(false);
       expect(isValidLandlinePhone([] as any)).toBe(false);

--- a/src/utilities/pis/index.test.ts
+++ b/src/utilities/pis/index.test.ts
@@ -6,19 +6,19 @@ describe('isValid', () => {
       RESERVED_NUMBERS.forEach((pis) => expect(isValid(pis)).toBe(false));
     });
 
-    test('when is a empty string', () => {
+    test('when it is an empty string', () => {
       expect(isValid('')).toBe(false);
     });
 
-    test('when is null', () => {
+    test('when it is null', () => {
       expect(isValid(null as any)).toBe(false);
     });
 
-    test('when is undefined', () => {
+    test('when it is undefined', () => {
       expect(isValid(undefined as any)).toBe(false);
     });
 
-    test('when is a boolean', () => {
+    test('when it is a boolean', () => {
       expect(isValid(true as any)).toBe(false);
       expect(isValid(false as any)).toBe(false);
     });


### PR DESCRIPTION
#112 
I found this issue and wanted to contribute to the repository for the first time. Speaking of which, excellent work guys.

When I started writing the tests, I saw that there was a small grammatical error in "a object" and I took the liberty to include the correction in this PR, but I can remove it if you think it is better.

Any mistakes that I may have made, or lack of standardization, or if something was missing, let me know and I'll be ready to correct.