### PR TITLE
Fix: Update travis.yml node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: node_js
 
 node_js:
-  - '13'
+  - '14'
   - '12'
-  - '11'
+  - '10'
 
 install:
 - npm install -g codecov


### PR DESCRIPTION
## References

ReferenceError on Travis CI Build (Node 11.x) #241

## Objectives

Fix Travis CI build pipelines

## Changes

Update travis.yml node versions from 13 and 11 to 14 and 10, same version as current GitHub's workflows