### PR TITLE
Feature: Get boleto info

### DIFF
--- a/docs/pt-br/utilities.md
+++ b/docs/pt-br/utilities.md
@@ -84,6 +84,21 @@ import { isValidBoleto } from '@brazilian-utils/brazilian-utils';
 isValidBoleto('00190000090114971860168524522114675860000102656'); // true
 ```
 
+## getBoletoInfo
+
+Retorna informações sobre um boleto válido.
+
+```javascript
+import { getBoletoInfo } from '@brazilian-utils/brazilian-utils';
+
+getBoletoInfo('00190000090114971860168524522114675860000102656');
+// {
+//   valueInCents: 102656,
+//   expirationDate: 2018-07-15T03:00:00.000Z,
+//   bankCode: '001'
+// }
+```
+
 ## isValidEmail
 
 Valida se email é valido.

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -28,7 +28,7 @@ formatCPF('746506880', { pad: true }); // 007.465.068-80
 Generate a valid random CPF.
 
 ```javascript
-import { generateCPF } from '@brazilian-utils/brazilian-utils'
+import { generateCPF } from '@brazilian-utils/brazilian-utils';
 
 generateCPF();
 ```
@@ -69,7 +69,7 @@ isValidCEP('92500000'); // true
 Generate a valid random CNPJ.
 
 ```javascript
-import { generateCNPJ } from '@brazilian-utils/brazilian-utils'
+import { generateCNPJ } from '@brazilian-utils/brazilian-utils';
 
 generateCNPJ();
 ```
@@ -82,6 +82,21 @@ Check if boleto ([brazilian payment method](https://en.wikipedia.org/wiki/Boleto
 import { isValidBoleto } from '@brazilian-utils/brazilian-utils';
 
 isValidBoleto('00190000090114971860168524522114675860000102656'); // true
+```
+
+## getBoletoInfo
+
+Get information about a valid boleto ([brazilian payment method](https://en.wikipedia.org/wiki/Boleto)).
+
+```javascript
+import { getBoletoInfo } from '@brazilian-utils/brazilian-utils';
+
+getBoletoInfo('00190000090114971860168524522114675860000102656');
+// {
+//   valueInCents: 102656,
+//   expirationDate: 2018-07-15T03:00:00.000Z,
+//   bankCode: '001'
+// }
 ```
 
 ## isValidEmail

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,6 +24,7 @@ describe('Public API', () => {
     'generateCNPJ',
     'formatBoleto',
     'isValidBoleto',
+    'getBoletoInfo',
     'generateChecksum',
     'generateRandomNumber',
     'getCities',

--- a/src/utilities/boleto/index.test.ts
+++ b/src/utilities/boleto/index.test.ts
@@ -1,4 +1,4 @@
-import { isValid, format, getValueInCents, getExpirationDate, LENGTH } from '.';
+import { isValid, format, getValueInCents, getExpirationDate, getBankCode, LENGTH } from '.';
 
 describe('isValid', () => {
   describe('should return false', () => {
@@ -185,6 +185,28 @@ describe('getExpirationDate', () => {
 
     test('should return the expiration date when boleto is with mask', () => {
       expect(getExpirationDate('0019000009 01149.718601 68524.522114 6 75860000102656')).toEqual(new Date(2018, 6, 15));
+    });
+  });
+});
+
+describe('getBankCode', () => {
+  describe('should return empty string', () => {
+    test('should return empty string when boleto is empty string', () => {
+      expect(getBankCode('')).toBe('');
+    });
+
+    test('should return empty string when boleto is invalid', () => {
+      expect(getBankCode('00190000090114971860168524522114775860000102656')).toBe('');
+    });
+  });
+
+  describe('should return bank code value', () => {
+    test('should return the bank code', () => {
+      expect(getBankCode('00190000090114971860168524522114675860000102656')).toEqual('001');
+    });
+
+    test('should return the bank code when boleto is with mask', () => {
+      expect(getBankCode('0019000009 01149.718601 68524.522114 6 75860000102656')).toEqual('001');
     });
   });
 });

--- a/src/utilities/boleto/index.test.ts
+++ b/src/utilities/boleto/index.test.ts
@@ -1,4 +1,4 @@
-import { isValid, format, LENGTH } from '.';
+import { isValid, format, getValueInCents, LENGTH } from '.';
 
 describe('isValid', () => {
   describe('should return false', () => {
@@ -143,4 +143,26 @@ describe('format', () => {
     expect(format('')).toBe('');
     expect(format('')).toBe('');
   });
+});
+
+describe('getValueInCents', () => {
+  describe('should return zero', () => {
+    test('should return zero value when boleto is empty string', () => {
+      expect(getValueInCents("")).toBe(0);
+    });
+
+    test('should return zero value when boleto is invalid', () => {
+      expect(getValueInCents("00190000090114971860168524522114775860000102656")).toBe(0);
+    });
+  });
+
+  describe('should return boleto value', () => {
+    test('should return the value in cents', () => {
+      expect(getValueInCents("00190000090114971860168524522114675860000102656")).toBe(102656);
+    });
+
+    test('should return value in cents when boleto is with mask' ,() => {
+      expect(getValueInCents("0019000009 01149.718601 68524.522114 6 75860000102656")).toBe(102656);
+    });
+  })
 });

--- a/src/utilities/boleto/index.test.ts
+++ b/src/utilities/boleto/index.test.ts
@@ -1,4 +1,4 @@
-import { isValid, format, getValueInCents, LENGTH } from '.';
+import { isValid, format, getValueInCents, getExpirationDate, LENGTH } from '.';
 
 describe('isValid', () => {
   describe('should return false', () => {
@@ -148,21 +148,43 @@ describe('format', () => {
 describe('getValueInCents', () => {
   describe('should return zero', () => {
     test('should return zero value when boleto is empty string', () => {
-      expect(getValueInCents("")).toBe(0);
+      expect(getValueInCents('')).toBe(0);
     });
 
     test('should return zero value when boleto is invalid', () => {
-      expect(getValueInCents("00190000090114971860168524522114775860000102656")).toBe(0);
+      expect(getValueInCents('00190000090114971860168524522114775860000102656')).toBe(0);
     });
   });
 
   describe('should return boleto value', () => {
     test('should return the value in cents', () => {
-      expect(getValueInCents("00190000090114971860168524522114675860000102656")).toBe(102656);
+      expect(getValueInCents('00190000090114971860168524522114675860000102656')).toBe(102656);
     });
 
-    test('should return value in cents when boleto is with mask' ,() => {
-      expect(getValueInCents("0019000009 01149.718601 68524.522114 6 75860000102656")).toBe(102656);
+    test('should return value in cents when boleto is with mask', () => {
+      expect(getValueInCents('0019000009 01149.718601 68524.522114 6 75860000102656')).toBe(102656);
     });
-  })
+  });
+});
+
+describe('getExpirationDate', () => {
+  describe('should return zero', () => {
+    test('should return null when boleto is empty string', () => {
+      expect(getExpirationDate('')).toBe(null);
+    });
+
+    test('should return null when boleto is invalid', () => {
+      expect(getExpirationDate('00190000090114971860168524522114775860000102656')).toBe(null);
+    });
+  });
+
+  describe('should return boleto value', () => {
+    test('should return the expiration date', () => {
+      expect(getExpirationDate('00190000090114971860168524522114675860000102656')).toEqual(new Date(2018, 6, 15));
+    });
+
+    test('should return the expiration date when boleto is with mask', () => {
+      expect(getExpirationDate('0019000009 01149.718601 68524.522114 6 75860000102656')).toEqual(new Date(2018, 6, 15));
+    });
+  });
 });

--- a/src/utilities/boleto/index.test.ts
+++ b/src/utilities/boleto/index.test.ts
@@ -1,4 +1,4 @@
-import { isValid, format, getValueInCents, getExpirationDate, getBankCode, LENGTH } from '.';
+import { isValid, format, getValueInCents, getExpirationDate, getBankCode, getInfo, LENGTH } from '.';
 
 describe('isValid', () => {
   describe('should return false', () => {
@@ -207,6 +207,36 @@ describe('getBankCode', () => {
 
     test('should return the bank code when boleto is with mask', () => {
       expect(getBankCode('0019000009 01149.718601 68524.522114 6 75860000102656')).toEqual('001');
+    });
+  });
+});
+
+describe('getInfo', () => {
+  describe('should throw error', () => {
+    test('should throw error when boleto is empty string', () => {
+      expect(() => getInfo('')).toThrow('Invalid boleto');
+    });
+
+    test('should throw error when boleto is invalid', () => {
+      expect(() => getInfo('00190000090114971860168524522114775860000102656')).toThrow('Invalid boleto');
+    });
+  });
+
+  describe('should return boleto info', () => {
+    test('should return the bank code', () => {
+      expect(getInfo('00190000090114971860168524522114675860000102656')).toStrictEqual({
+        valueInCents: 102656,
+        expirationDate: new Date(2018, 6, 15),
+        bankCode: '001',
+      });
+    });
+
+    test('should return the bank code when boleto is with mask', () => {
+      expect(getInfo('0019000009 01149.718601 68524.522114 6 75860000102656')).toStrictEqual({
+        valueInCents: 102656,
+        expirationDate: new Date(2018, 6, 15),
+        bankCode: '001',
+      });
     });
   });
 });

--- a/src/utilities/boleto/index.ts
+++ b/src/utilities/boleto/index.ts
@@ -41,6 +41,10 @@ export const DIGITABLE_LINE_TO_BOLETO_CONVERT_POSITIONS = [
   { end: 31, start: 21 },
 ];
 
+export interface Boleto {
+  value: number;
+}
+
 function isValidLength(digitableLine: string): boolean {
   return digitableLine.length === LENGTH;
 }
@@ -133,4 +137,14 @@ export function format(boleto: string) {
 
       return result;
     }, '');
+}
+
+export function getValueInCents(digitableLine: string): number {
+  if (!digitableLine || !isValid(digitableLine)) return 0;
+
+  const digits = onlyNumbers(digitableLine);
+
+  const valueStartIndex = digits.length - 10;
+
+  return Number(digits.substr(valueStartIndex));
 }

--- a/src/utilities/boleto/index.ts
+++ b/src/utilities/boleto/index.ts
@@ -160,10 +160,10 @@ export function getExpirationDate(digitableLine: string): Date | null {
   const daysSinceBaseDayEndIndex = -10;
   const daysSinceBaseDay = digitableLine.slice(daysSinceBaseDayStartIndex, daysSinceBaseDayEndIndex);
 
-  const oneDayMiliseconds = 24 * 60 * 60 * 1000;
-  const milisecondsSinceBaseDay = Number(daysSinceBaseDay) * oneDayMiliseconds;
+  const oneDayMilliseconds = 24 * 60 * 60 * 1000;
+  const millisecondsSinceBaseDay = Number(daysSinceBaseDay) * oneDayMilliseconds;
 
-  const dateSinceBaseDay = new Date(milisecondsSinceBaseDay);
+  const dateSinceBaseDay = new Date(millisecondsSinceBaseDay);
 
   return new Date(dateSinceBaseDay.getTime() + BANCO_CENTRAL_BASE_DATE.getTime());
 }

--- a/src/utilities/boleto/index.ts
+++ b/src/utilities/boleto/index.ts
@@ -160,3 +160,9 @@ export function getExpirationDate(digitableLine: string): Date | null {
 
   return new Date(dateSinceFirstDay.getTime() + firstDay.getTime());
 }
+
+export function getBankCode(digitableLine: string): string {
+  if (!digitableLine || !isValid(digitableLine)) return '';
+
+  return digitableLine.substr(0, 3);
+}

--- a/src/utilities/boleto/index.ts
+++ b/src/utilities/boleto/index.ts
@@ -43,6 +43,7 @@ export const DIGITABLE_LINE_TO_BOLETO_CONVERT_POSITIONS = [
 
 export interface Boleto {
   value: number;
+  expirationDate: Date;
 }
 
 function isValidLength(digitableLine: string): boolean {
@@ -147,4 +148,15 @@ export function getValueInCents(digitableLine: string): number {
   const valueStartIndex = digits.length - 10;
 
   return Number(digits.substr(valueStartIndex));
+}
+
+export function getExpirationDate(digitableLine: string): Date | null {
+  if (!digitableLine || !isValid(digitableLine)) return null;
+
+  const firstDay = new Date(1997, 9, 7);
+
+  const daysSinceFirstDay = digitableLine.substr(digitableLine.length - 14, 4);
+  const dateSinceFirstDay = new Date(Number(daysSinceFirstDay) * 24 * 60 * 60 * 1000);
+
+  return new Date(dateSinceFirstDay.getTime() + firstDay.getTime());
 }

--- a/src/utilities/boleto/index.ts
+++ b/src/utilities/boleto/index.ts
@@ -41,6 +41,8 @@ export const DIGITABLE_LINE_TO_BOLETO_CONVERT_POSITIONS = [
   { end: 31, start: 21 },
 ];
 
+export const BANCO_CENTRAL_BASE_DATE = new Date(1997, 9, 7);
+
 export interface Boleto {
   valueInCents: number;
   expirationDate: Date | null;
@@ -146,20 +148,24 @@ export function getValueInCents(digitableLine: string): number {
 
   const digits = onlyNumbers(digitableLine);
 
-  const valueStartIndex = digits.length - 10;
+  const valueStartIndex = -10;
 
-  return Number(digits.substr(valueStartIndex));
+  return Number(digits.slice(valueStartIndex));
 }
 
 export function getExpirationDate(digitableLine: string): Date | null {
   if (!digitableLine || !isValid(digitableLine)) return null;
 
-  const firstDay = new Date(1997, 9, 7);
+  const daysSinceBaseDayStartIndex = -14;
+  const daysSinceBaseDayEndIndex = -10;
+  const daysSinceBaseDay = digitableLine.slice(daysSinceBaseDayStartIndex, daysSinceBaseDayEndIndex);
 
-  const daysSinceFirstDay = digitableLine.substr(digitableLine.length - 14, 4);
-  const dateSinceFirstDay = new Date(Number(daysSinceFirstDay) * 24 * 60 * 60 * 1000);
+  const oneDayMiliseconds = 24 * 60 * 60 * 1000;
+  const milisecondsSinceBaseDay = Number(daysSinceBaseDay) * oneDayMiliseconds;
 
-  return new Date(dateSinceFirstDay.getTime() + firstDay.getTime());
+  const dateSinceBaseDay = new Date(milisecondsSinceBaseDay);
+
+  return new Date(dateSinceBaseDay.getTime() + BANCO_CENTRAL_BASE_DATE.getTime());
 }
 
 export function getBankCode(digitableLine: string): string {

--- a/src/utilities/boleto/index.ts
+++ b/src/utilities/boleto/index.ts
@@ -42,8 +42,9 @@ export const DIGITABLE_LINE_TO_BOLETO_CONVERT_POSITIONS = [
 ];
 
 export interface Boleto {
-  value: number;
-  expirationDate: Date;
+  valueInCents: number;
+  expirationDate: Date | null;
+  bankCode: string;
 }
 
 function isValidLength(digitableLine: string): boolean {
@@ -165,4 +166,14 @@ export function getBankCode(digitableLine: string): string {
   if (!digitableLine || !isValid(digitableLine)) return '';
 
   return digitableLine.substr(0, 3);
+}
+
+export function getInfo(digitableLine: string): Boleto {
+  if (!digitableLine || !isValid(digitableLine)) throw new Error('Invalid boleto');
+
+  return {
+    valueInCents: getValueInCents(digitableLine),
+    expirationDate: getExpirationDate(digitableLine),
+    bankCode: getBankCode(digitableLine),
+  };
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -4,7 +4,7 @@ export { isValid as isValidPhone, isValidMobilePhone, isValidLandlinePhone } fro
 export { isValid as isValidEmail } from './email';
 export { format as formatProcessoJuridico, isValid as isValidProcessoJuridico } from './processo-juridico';
 export { format as formatCEP, isValid as isValidCEP } from './cep';
-export { format as formatBoleto, isValid as isValidBoleto } from './boleto';
+export { format as formatBoleto, isValid as isValidBoleto, getInfo as getBoletoInfo } from './boleto';
 export { format as formatCurrency, parse as parseCurrency } from './currency';
 export { format as formatCPF, generate as generateCPF, isValid as isValidCPF } from './cpf';
 export { format as formatCNPJ, generate as generateCNPJ, isValid as isValidCNPJ } from './cnpj';


### PR DESCRIPTION
## References

[Feature request] Get "boleto" information from digitable line #239

## Objectives

Create getBoletoInfo function to get data from a valid boleto.

Usage example:

```javascript
>> getBoletoInfo('23793381286006069409261000063307486470000004200');

>> {
    valueInCents: 4200,
    expirationDate: 2021-06-10T03:00:00.000Z,
    bankCode: '237'
   }
```

## Changes

* Create getValueInCents function
* Create getExpirationDate function
* Create getBankCode function
* Create Boleto interface
* Create getInfo function and export it as getBoletoInfo
* Add getBoletoInfo to docs

## Notes

The `currency` field mentioned at #239 hasn't been added because, most of cases, the brazilian payment method will be charged with BRL values.