### PR TITLE
feat: new cnpj alphanumeric

### DIFF
--- a/docs/pt-br/utilities.md
+++ b/docs/pt-br/utilities.md
@@ -41,6 +41,14 @@ Valida se o CNPJ é válido.
 import { isValidCNPJ } from '@brazilian-utils/brazilian-utils';
 
 isValidCNPJ('15515147234255'); // false
+
+/*
+ * valida um CNPJ versão 2, alfanumérico.
+ * Conforme a Nota Técnica COCAD/SUARA/RFB nº 49/2024, 
+ * o CNPJ passará a combinar números e letras. 
+ * A versão 2 segue essa norma técnica.
+*/
+isValidCNPJ('1D4N1A9K2ZQQ30', { version: '2' }); // false
 ```
 
 ## formatCNPJ
@@ -52,9 +60,17 @@ import { formatCNPJ } from '@brazilian-utils/brazilian-utils';
 
 formatCNPJ('245222000174'); // 24.522.200/0174
 formatCNPJ('245222000174', { pad: true }); // 00.245.222/0001-74
+
+/*
+ * Format CNPJ versão 2, alfanumérico.
+ * Conforme a Nota Técnica COCAD/SUARA/RFB nº 49/2024, 
+ * o CNPJ passará a combinar números e letras. 
+ * A versão 2 dessa função segue essa norma técnica.
+*/
+formatCNPJ('PD4N1A9K1ZQQ39', { version: '2' }); // PD.4N1.A9K.1ZQQ/39
 ```
 
-## generateCPF
+## generateCNPJ
 
 Gera um CNPJ válido aleatório.
 
@@ -62,6 +78,14 @@ Gera um CNPJ válido aleatório.
 import { generateCNPJ } from '@brazilian-utils/brazilian-utils'
 
 generateCNPJ();
+
+/*
+ * Gera um CNPJ válido versão 2, alfanumérico.
+ * Conforme a Nota Técnica COCAD/SUARA/RFB nº 49/2024, 
+ * o CNPJ passará a combinar números e letras. 
+ * A versão 2 segue essa norma técnica.
+*/
+generateCNPJ({ version: '2' });
 ```
 
 ## isValidCEP

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -41,6 +41,14 @@ Check if CNPJ is valid.
 import { isValidCNPJ } from '@brazilian-utils/brazilian-utils';
 
 isValidCNPJ('15515147234255'); // false
+
+/*
+ * validate CNPJ version 2, alphanumeric.
+ * According to Technical Note COCAD/SUARA/RFB No. 49/2024, 
+ * the CNPJ will combine numbers and letters. 
+ * Version 2 follows this technical.
+*/
+isValidCNPJ('1D4N1A9K2ZQQ30', { version: '2' }); // false
 ```
 
 ## formatCNPJ
@@ -52,6 +60,14 @@ import { formatCNPJ } from '@brazilian-utils/brazilian-utils';
 
 formatCNPJ('245222000174'); // 24.522.200/0174
 formatCNPJ('245222000174', { pad: true }); // 00.245.222/0001-74
+
+/*
+ * Format CNPJ version 2, alphanumeric.
+ * According to Technical Note COCAD/SUARA/RFB No. 49/2024, 
+ * the CNPJ will combine numbers and letters. 
+ * Version 2 follows this technical.
+*/
+formatCNPJ('PD4N1A9K1ZQQ39', { version: '2' }); // PD.4N1.A9K.1ZQQ/39
 ```
 
 ## isValidCEP
@@ -72,6 +88,14 @@ Generate a valid random CNPJ.
 import { generateCNPJ } from '@brazilian-utils/brazilian-utils'
 
 generateCNPJ();
+
+/*
+ * Generates a valid random CNPJ version 2, alphanumeric.
+ * According to Technical Note COCAD/SUARA/RFB No. 49/2024,
+ * the CNPJ will combine numbers and letters. 
+ * Version 2 follows this technical standard.
+*/
+generateCNPJ({ version: '2' });
 ```
 
 ## isValidBoleto

--- a/src/utilities/cnpj/index.test.ts
+++ b/src/utilities/cnpj/index.test.ts
@@ -19,6 +19,25 @@ describe('format', () => {
     expect(format('46843485000186')).toBe('46.843.485/0001-86');
   });
 
+  
+  test('should format cnpj alphanumeric with mask', () => {
+    expect(format('')).toBe('');
+    expect(format('Q')).toBe('Q');
+    expect(format('Q0')).toBe('Q0');
+    expect(format('Q0S')).toBe('Q0.S');
+    expect(format('Q0SL')).toBe('Q0.SL');
+    expect(format('Q0SLF')).toBe('Q0.SLF');
+    expect(format('Q0SLFM')).toBe('Q0.SLF.M');
+    expect(format('Q0SLFMB')).toBe('Q0.SLF.MB');
+    expect(format('Q0SLFMBD')).toBe('Q0.SLF.MBD');
+    expect(format('Q0SLFMBD7')).toBe('Q0.SLF.MBD/7');
+    expect(format('Q0SLFMBD7V')).toBe('Q0.SLF.MBD/7V');
+    expect(format('Q0SLFMBD7VX')).toBe('Q0.SLF.MBD/7VX');
+    expect(format('Q0SLFMBD7VX4')).toBe('Q0.SLF.MBD/7VX4');
+    expect(format('Q0SLFMBD7VX43')).toBe('Q0.SLF.MBD/7VX4-3');
+    expect(format('q0SLFMBD7VX439')).toBe('Q0.SLF.MBD/7VX4-39');
+  });
+
   test('should format number cnpj with mask', () => {
     expect(format(4)).toBe('4');
     expect(format(46)).toBe('46');
@@ -76,7 +95,7 @@ describe('format', () => {
   });
 
   test('should remove all non numeric characters', () => {
-    expect(format('46.?ABC843.485/0001-86abc')).toBe('46.843.485/0001-86');
+    expect(format('46.?ABC843.485/0001-86abc')).toBe('46.ABC.843/4850-00');
   });
 });
 

--- a/src/utilities/cnpj/index.test.ts
+++ b/src/utilities/cnpj/index.test.ts
@@ -1,4 +1,8 @@
-import { format, LENGTH, isValid, generate, RESERVED_NUMBERS, FormatCnpjOptions, CnpjVersions } from '.';
+import { format, LENGTH, isValid, generate, RESERVED_NUMBERS, CnpjVersions } from '.';
+
+function randomCnpjOptionVersion2StringOrNumber(): '2' | 2 {
+  return Math.random() < 0.5 ? '2' : 2;
+}
 
 describe('format', () => {
   test('should format cnpj with mask', () => {
@@ -20,25 +24,21 @@ describe('format', () => {
   });
 
   test('should format cnpj alphanumeric with mask for version 2', () => {
-    const options: FormatCnpjOptions = {
-      version: '2',
-    };
-
-    expect(format('', options)).toBe('');
-    expect(format('Q', options)).toBe('Q');
-    expect(format('Q0', options)).toBe('Q0');
-    expect(format('Q0S', options)).toBe('Q0.S');
-    expect(format('Q0SL', options)).toBe('Q0.SL');
-    expect(format('Q0SLF', options)).toBe('Q0.SLF');
-    expect(format('Q0SLFM', options)).toBe('Q0.SLF.M');
-    expect(format('Q0SLFMB', options)).toBe('Q0.SLF.MB');
-    expect(format('Q0SLFMBD', options)).toBe('Q0.SLF.MBD');
-    expect(format('Q0SLFMBD7', options)).toBe('Q0.SLF.MBD/7');
-    expect(format('Q0SLFMBD7V', options)).toBe('Q0.SLF.MBD/7V');
-    expect(format('Q0SLFMBD7VX', options)).toBe('Q0.SLF.MBD/7VX');
-    expect(format('Q0SLFMBD7VX4', options)).toBe('Q0.SLF.MBD/7VX4');
-    expect(format('Q0SLFMBD7VX43', options)).toBe('Q0.SLF.MBD/7VX4-3');
-    expect(format('q0SLFMBD7VX439', options)).toBe('Q0.SLF.MBD/7VX4-39');
+    expect(format('', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('');
+    expect(format('Q', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q');
+    expect(format('Q0', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0');
+    expect(format('Q0S', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.S');
+    expect(format('Q0SL', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SL');
+    expect(format('Q0SLF', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SLF');
+    expect(format('Q0SLFM', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SLF.M');
+    expect(format('Q0SLFMB', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SLF.MB');
+    expect(format('Q0SLFMBD', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SLF.MBD');
+    expect(format('Q0SLFMBD7', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SLF.MBD/7');
+    expect(format('Q0SLFMBD7V', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SLF.MBD/7V');
+    expect(format('Q0SLFMBD7VX', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SLF.MBD/7VX');
+    expect(format('Q0SLFMBD7VX4', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SLF.MBD/7VX4');
+    expect(format('Q0SLFMBD7VX43', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SLF.MBD/7VX4-3');
+    expect(format('q0SLFMBD7VX439', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe('Q0.SLF.MBD/7VX4-39');
   });
 
   test('should format number cnpj with mask', () => {
@@ -102,7 +102,9 @@ describe('format', () => {
   });
 
   test('should remove non-alphanumeric characters for version 2', () => {
-    expect(format('46.?ABC843.485/0001-86abc', { version: '2' })).toBe('46.ABC.843/4850-00');
+    expect(format('46.?ABC843.485/0001-86abc', { version: randomCnpjOptionVersion2StringOrNumber() })).toBe(
+      '46.ABC.843/4850-00'
+    );
   });
 });
 
@@ -119,9 +121,9 @@ describe('generate', () => {
   });
 
   test('should return valid CNPJ version 2', () => {
-    const options: { version?: CnpjVersions } = { version: '2' };
     // iterate over 100 to insure that random generated CPNJ is valid
     for (let i = 0; i < 100; i++) {
+      const options: { version?: CnpjVersions } = { version: randomCnpjOptionVersion2StringOrNumber() };
       expect(isValid(generate(options), options)).toBe(true);
     }
   });

--- a/src/utilities/cnpj/index.test.ts
+++ b/src/utilities/cnpj/index.test.ts
@@ -19,7 +19,6 @@ describe('format', () => {
     expect(format('46843485000186')).toBe('46.843.485/0001-86');
   });
 
-  
   test('should format cnpj alphanumeric with mask', () => {
     expect(format('')).toBe('');
     expect(format('Q')).toBe('Q');

--- a/src/utilities/cnpj/index.test.ts
+++ b/src/utilities/cnpj/index.test.ts
@@ -1,4 +1,4 @@
-import { format, LENGTH, isValid, generate, RESERVED_NUMBERS } from '.';
+import { format, LENGTH, isValid, generate, RESERVED_NUMBERS, FormatCnpjOptions, CnpjVersions } from '.';
 
 describe('format', () => {
   test('should format cnpj with mask', () => {
@@ -19,22 +19,26 @@ describe('format', () => {
     expect(format('46843485000186')).toBe('46.843.485/0001-86');
   });
 
-  test('should format cnpj alphanumeric with mask', () => {
-    expect(format('')).toBe('');
-    expect(format('Q')).toBe('Q');
-    expect(format('Q0')).toBe('Q0');
-    expect(format('Q0S')).toBe('Q0.S');
-    expect(format('Q0SL')).toBe('Q0.SL');
-    expect(format('Q0SLF')).toBe('Q0.SLF');
-    expect(format('Q0SLFM')).toBe('Q0.SLF.M');
-    expect(format('Q0SLFMB')).toBe('Q0.SLF.MB');
-    expect(format('Q0SLFMBD')).toBe('Q0.SLF.MBD');
-    expect(format('Q0SLFMBD7')).toBe('Q0.SLF.MBD/7');
-    expect(format('Q0SLFMBD7V')).toBe('Q0.SLF.MBD/7V');
-    expect(format('Q0SLFMBD7VX')).toBe('Q0.SLF.MBD/7VX');
-    expect(format('Q0SLFMBD7VX4')).toBe('Q0.SLF.MBD/7VX4');
-    expect(format('Q0SLFMBD7VX43')).toBe('Q0.SLF.MBD/7VX4-3');
-    expect(format('q0SLFMBD7VX439')).toBe('Q0.SLF.MBD/7VX4-39');
+  test('should format cnpj alphanumeric with mask for version 2', () => {
+    const options: FormatCnpjOptions = {
+      version: '2',
+    };
+
+    expect(format('', options)).toBe('');
+    expect(format('Q', options)).toBe('Q');
+    expect(format('Q0', options)).toBe('Q0');
+    expect(format('Q0S', options)).toBe('Q0.S');
+    expect(format('Q0SL', options)).toBe('Q0.SL');
+    expect(format('Q0SLF', options)).toBe('Q0.SLF');
+    expect(format('Q0SLFM', options)).toBe('Q0.SLF.M');
+    expect(format('Q0SLFMB', options)).toBe('Q0.SLF.MB');
+    expect(format('Q0SLFMBD', options)).toBe('Q0.SLF.MBD');
+    expect(format('Q0SLFMBD7', options)).toBe('Q0.SLF.MBD/7');
+    expect(format('Q0SLFMBD7V', options)).toBe('Q0.SLF.MBD/7V');
+    expect(format('Q0SLFMBD7VX', options)).toBe('Q0.SLF.MBD/7VX');
+    expect(format('Q0SLFMBD7VX4', options)).toBe('Q0.SLF.MBD/7VX4');
+    expect(format('Q0SLFMBD7VX43', options)).toBe('Q0.SLF.MBD/7VX4-3');
+    expect(format('q0SLFMBD7VX439', options)).toBe('Q0.SLF.MBD/7VX4-39');
   });
 
   test('should format number cnpj with mask', () => {
@@ -94,7 +98,11 @@ describe('format', () => {
   });
 
   test('should remove all non numeric characters', () => {
-    expect(format('46.?ABC843.485/0001-86abc')).toBe('46.ABC.843/4850-00');
+    expect(format('46.?ABC843.485/0001-86abc')).toBe('46.843.485/0001-86');
+  });
+
+  test('should remove non-alphanumeric characters for version 2', () => {
+    expect(format('46.?ABC843.485/0001-86abc', { version: '2' })).toBe('46.ABC.843/4850-00');
   });
 });
 
@@ -107,6 +115,14 @@ describe('generate', () => {
     // iterate over 100 to insure that random generated CPNJ is valid
     for (let i = 0; i < 100; i++) {
       expect(isValid(generate())).toBe(true);
+    }
+  });
+
+  test('should return valid CNPJ version 2', () => {
+    const options: { version?: CnpjVersions } = { version: '2' };
+    // iterate over 100 to insure that random generated CPNJ is valid
+    for (let i = 0; i < 100; i++) {
+      expect(isValid(generate(options), options)).toBe(true);
     }
   });
 });

--- a/src/utilities/cnpj/index.ts
+++ b/src/utilities/cnpj/index.ts
@@ -29,14 +29,14 @@ export const SECOND_CHECK_DIGIT_WEIGHTS = [6, ...FIRST_CHECK_DIGIT_WEIGHTS];
 
 const VALID_CHARS = '0123456789ABCDFGHIJKLMNPQRSVWXYZ';
 
-export type CnpjVersions = '1' | '2';
+export type CnpjVersions = '1' | '2' | 1 | 2;
 export interface FormatCnpjOptions {
   pad?: boolean;
   version?: CnpjVersions;
 }
 
 export function format(cnpj: string | number, options: FormatCnpjOptions = {}): string {
-  let digits = options.version === '2' ? onlyValidCNPJAlphanumeric(String(cnpj).toUpperCase()) : onlyNumbers(cnpj);
+  let digits = options.version == 2 ? onlyValidCNPJAlphanumeric(String(cnpj).toUpperCase()) : onlyNumbers(cnpj);
 
   if (options.pad) {
     digits = digits.padStart(LENGTH, '0');
@@ -83,13 +83,11 @@ function generateCNPJAlphanumericChars(length: number): string {
 }
 
 export interface GenerateCnpjOptions {
-  // botar um type Vesions
   version?: CnpjVersions;
 }
 
 export function generate(options: GenerateCnpjOptions = {}): string {
-  const baseCNPJ =
-    options.version === '2' ? generateCNPJAlphanumericChars(LENGTH - 2) : generateRandomNumber(LENGTH - 2);
+  const baseCNPJ = options.version == 2 ? generateCNPJAlphanumericChars(LENGTH - 2) : generateRandomNumber(LENGTH - 2);
 
   const firstCheckDigitMod = generateChecksum(baseCNPJ, FIRST_CHECK_DIGIT_WEIGHTS) % 11;
   const firstCheckDigit = (firstCheckDigitMod < 2 ? 0 : 11 - firstCheckDigitMod).toString();
@@ -133,14 +131,13 @@ export function isValidChecksum(cnpj: string): boolean {
 }
 
 export interface isValidCnpjOptions {
-  // botar um type Vesions
   version?: CnpjVersions;
 }
 
 export function isValid(cnpj: string, options: isValidCnpjOptions = {}): boolean {
   if (!cnpj || typeof cnpj !== 'string') return false;
 
-  const validValue = options.version === '2' ? onlyValidCNPJAlphanumeric(cnpj) : onlyNumbers(cnpj);
+  const validValue = options.version == 2 ? onlyValidCNPJAlphanumeric(cnpj) : onlyNumbers(cnpj);
 
   return isValidFormat(cnpj) && !isReservedNumber(validValue) && isValidChecksum(validValue);
 }

--- a/src/utilities/cnpj/index.ts
+++ b/src/utilities/cnpj/index.ts
@@ -27,7 +27,7 @@ export const FIRST_CHECK_DIGIT_WEIGHTS = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
 
 export const SECOND_CHECK_DIGIT_WEIGHTS = [6, ...FIRST_CHECK_DIGIT_WEIGHTS];
 
-const VALID_CHARS_CNPJ = '0123456789ABCDFGHIJKLMNPQRSVWXYZ'
+const VALID_CHARS_CNPJ = '0123456789ABCDFGHIJKLMNPQRSVWXYZ';
 
 export interface FormatCnpjOptions {
   pad?: boolean;
@@ -64,7 +64,7 @@ function charToAsciiValue(char: string): number {
 function onlyValidCNPJAlphanumeric(input: string): string {
   return input
     .split('')
-    .filter(char => VALID_CHARS_CNPJ.includes(char))
+    .filter((char) => VALID_CHARS_CNPJ.includes(char))
     .join('');
 }
 
@@ -85,10 +85,9 @@ function generateCNPJAlphanumericChars(length: number): string {
     .join('');
 }
 
-
 export function generate(): string {
   const baseCNPJ = generateCNPJAlphanumericChars(LENGTH - 2);
-  
+
   const firstCheckDigitMod = generateChecksumCNPJ(baseCNPJ, FIRST_CHECK_DIGIT_WEIGHTS) % 11;
   const firstCheckDigit = (firstCheckDigitMod < 2 ? 0 : 11 - firstCheckDigitMod).toString();
 
@@ -99,7 +98,9 @@ export function generate(): string {
 }
 
 function isValidFormat(cnpj: string): boolean {
-  return /^[0-9ABCDFGHIJKLMNPQRSVWXYZ]{2}\.?[0-9ABCDFGHIJKLMNPQRSVWXYZ]{3}\.?[0-9ABCDFGHIJKLMNPQRSVWXYZ]{3}\/?[0-9ABCDFGHIJKLMNPQRSVWXYZ]{4}-?\d{2}$/.test(cnpj);
+  return /^[0-9ABCDFGHIJKLMNPQRSVWXYZ]{2}\.?[0-9ABCDFGHIJKLMNPQRSVWXYZ]{3}\.?[0-9ABCDFGHIJKLMNPQRSVWXYZ]{3}\/?[0-9ABCDFGHIJKLMNPQRSVWXYZ]{4}-?\d{2}$/.test(
+    cnpj
+  );
 }
 
 export function isReservedNumber(cpf: string): boolean {
@@ -132,7 +133,6 @@ export function isValid(cnpj: string): boolean {
   if (!cnpj || typeof cnpj !== 'string') return false;
 
   const validValue = onlyValidCNPJAlphanumeric(cnpj);
-
 
   return isValidFormat(cnpj) && !isReservedNumber(validValue) && isValidChecksum(validValue);
 }

--- a/src/utilities/email/index.ts
+++ b/src/utilities/email/index.ts
@@ -2,8 +2,7 @@ const MAX_RECIPIENT_LENGTH = 64;
 const MAX_DOMAIN_LENGTH = 253;
 const MAX_EMAIL_LENGTH = MAX_RECIPIENT_LENGTH + 1 + MAX_DOMAIN_LENGTH;
 
-const validEmailRegex =
-  /^([!#$%&'*+\-/=?^_`{|}~]{0,1}([a-zA-Z0-9][!#$%&'*+\-/=?^_`{|}~.]{0,1})+)@(([a-zA-Z0-9][-.]{0,1})+)([.]{1}[a-zA-Z0-9]+)$/;
+const validEmailRegex = /^([!#$%&'*+\-/=?^_`{|}~]{0,1}([a-zA-Z0-9][!#$%&'*+\-/=?^_`{|}~.]{0,1})+)@(([a-zA-Z0-9][-.]{0,1})+)([.]{1}[a-zA-Z0-9]+)$/;
 
 const stringIsBiggerThan = (len: number, ...strs: string[]): boolean =>
   strs.reduce((length, s) => length + s.length, 0) > len;

--- a/src/utilities/email/index.ts
+++ b/src/utilities/email/index.ts
@@ -2,7 +2,8 @@ const MAX_RECIPIENT_LENGTH = 64;
 const MAX_DOMAIN_LENGTH = 253;
 const MAX_EMAIL_LENGTH = MAX_RECIPIENT_LENGTH + 1 + MAX_DOMAIN_LENGTH;
 
-const validEmailRegex = /^([!#$%&'*+\-/=?^_`{|}~]{0,1}([a-zA-Z0-9][!#$%&'*+\-/=?^_`{|}~.]{0,1})+)@(([a-zA-Z0-9][-.]{0,1})+)([.]{1}[a-zA-Z0-9]+)$/;
+const validEmailRegex =
+  /^([!#$%&'*+\-/=?^_`{|}~]{0,1}([a-zA-Z0-9][!#$%&'*+\-/=?^_`{|}~.]{0,1})+)@(([a-zA-Z0-9][-.]{0,1})+)([.]{1}[a-zA-Z0-9]+)$/;
 
 const stringIsBiggerThan = (len: number, ...strs: string[]): boolean =>
   strs.reduce((length, s) => length + s.length, 0) > len;


### PR DESCRIPTION
Adiciona validação e formatação do novo CNPJ alfanumérico

## Pontos de Atenção:
- Tecnicamente, estamos introduzindo uma "breaking change" na validação do CNPJ, pois anteriormente não aceitávamos caracteres que não fossem números (havia testes validando isso que foram alterados nesta pr).
- Agora, passamos a permitir caracteres alfanuméricos, o que quebra o comportamento anterior.
- Precisamos considerar que essa mudança pode impactar nas versões anteriores a esta pr, que dependem da validação estritamente numérica.
- Talvez seja interessante adicionar uma flag com option param nas funções alteradas para indicar que a validação deve considerar o novo formato alfanumérico.

Fico à disposição para pensarmos na melhor maneira de implementar isso.

resolve #361